### PR TITLE
Make OpenMP optional

### DIFF
--- a/Src/SurfaceTrimmer.cpp
+++ b/Src/SurfaceTrimmer.cpp
@@ -29,7 +29,9 @@ DAMAGE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <float.h>
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 #include <algorithm>
 #include "CmdLineParser.h"
 #include "Geometry.h"


### PR DESCRIPTION
OpenMP is not included in the compilers on Mac OS X, so in order to use it developers would need to recompile their own compilers.  Un-fun.

This PR just adds a preprocessor check **_OPENMP** around the *omp.h* include.  This is supposed to be defined by compilers which support OpenMP.

From the OpenMP spec:
> In implementations that support a preprocessor, the _OPENMP macro name is defined to
have the decimal value yyyymm where yyyy and mm are the year and month designations
of the version of the OpenMP API that the implementation supports.