### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Src/Allocator.h
+++ b/Src/Allocator.h
@@ -117,7 +117,7 @@ public:
 				remains=state.remains;
 			}
 			else{
-				for(int j=0;j<state.remains;j<remains){
+				for(int j=0;j<state.remains;j++){
 					memory[index][j].~T();
 					new(&memory[index][j]) T();
 				}

--- a/Src/Geometry.h
+++ b/Src/Geometry.h
@@ -253,7 +253,6 @@ public:
 		double d=0;
 		int i,j;
 		for(i=0;i<3;i++){
-	  for(i=0;i<3;i++)
 			for(j=0;j<3;j++){d+=(p[(i+1)%3][j]-p[i][j])*(p[(i+1)%3][j]-p[i][j]);}
 		}
 		return Area()/d;

--- a/Src/SparseMatrix.inl
+++ b/Src/SparseMatrix.inl
@@ -209,7 +209,7 @@ SparseMatrix<T> SparseMatrix<T>::operator * (const T& V) const
 template<class T>
 SparseMatrix<T>& SparseMatrix<T>::operator *= (const T& V)
 {
-	for( int i=0 ; i<rows ; i++ ) for( int ii=0 ; ii<rowSizes[i] ; i++ ) m_ppElements[i][ii].Value *= V;
+	for( int i=0 ; i<rows ; i++ ) for( int ii=0 ; ii<rowSizes[i] ; ii++ ) m_ppElements[i][ii].Value *= V;
 	return *this;
 }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V533](https://www.viva64.com/en/w/v533/) It is likely that a wrong variable is being incremented inside the 'for' operator. Consider reviewing 'i'. sparsematrix.inl 212
[V535](https://www.viva64.com/en/w/v535/) The variable 'i' is being used for this loop and for the outer loop. Check lines: 255, 256. geometry.h 256
[V607](https://www.viva64.com/en/w/v607/) Ownerless expression 'j < remains'. allocator.h 120