### PR TITLE
Fix issues which prevent compiling with clang

### DIFF
--- a/Src/PointStream.inl
+++ b/Src/PointStream.inl
@@ -153,7 +153,7 @@ void PLYInputPointStream< Real , Dim >::reset( void )
 			exit( 0 );
 		}	
 
-		if( elem_name=="vertex" , elem_name )
+		if( elem_name=="vertex" )
 		{
 			foundVertices = true;
 			_pCount = num_elems , _pIdx = 0;

--- a/Src/RegularTree.inl
+++ b/Src/RegularTree.inl
@@ -627,7 +627,7 @@ RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< UIntPa
 #if 1
 template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
 template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
-RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< UIntPack< LeftRadii ... > , UIntPack< RightRadii ... > >& RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< UIntPack< LeftRadii ... > , UIntPack< RightRadii ... > >::operator = ( const ConstNeighborKey& key )
+typename RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::template ConstNeighborKey< UIntPack< LeftRadii ... > , UIntPack< RightRadii ... > >& RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< UIntPack< LeftRadii ... > , UIntPack< RightRadii ... > >::operator = ( const ConstNeighborKey& key )
 {
 	set( key._depth );
 	for( int d=0 ; d<=_depth ; d++ ) memcpy( &neighbors[d] , &key.neighbors[d] , sizeof( ConstNeighbors< UIntPack< ( LeftRadii + RightRadii + 1 ) ... > > ) );


### PR DESCRIPTION
I ran into two issues getting this to compile on OS X 10.14.1 with clang version `Apple LLVM version 10.0.0 (clang-1000.11.45.5) Target: x86_64-apple-darwin18.2.0`. If they're appropriate for merging that'd be great, but otherwise I hope they can serve as a quick hint for other people who might encounter this. Thanks for the incredible work!