### PR TITLE
support for multi CPU

### DIFF
--- a/Src/AdaptiveTreeVisualization.cpp
+++ b/Src/AdaptiveTreeVisualization.cpp
@@ -65,7 +65,7 @@ cmdLineParameter< int >
 #endif // _OPENMP
 	ScheduleType( "schedule" , (int)ThreadPool::DefaultSchedule ) ,
 	ThreadChunkSize( "chunkSize" , (int)ThreadPool::DefaultChunkSize ) ,
-	Threads( "threads" , (int)std::thread::hardware_concurrency() ) ,
+	Threads( "threads" , (int)numMaxThreads) ,
 	TreeScale( "treeScale" , 1 ) ,
 	TreeDepth( "treeDepth" , -1 );
 

--- a/Src/CoredMesh.inl
+++ b/Src/CoredMesh.inl
@@ -31,7 +31,7 @@ DAMAGE.
 // CoredVectorMeshData //
 /////////////////////////
 template< class Vertex , typename Index >
-CoredVectorMeshData< Vertex , Index >::CoredVectorMeshData( void ) { oocPointIndex = polygonIndex = threadIndex = 0 ; polygons.resize( std::thread::hardware_concurrency() ); }
+CoredVectorMeshData< Vertex , Index >::CoredVectorMeshData( void ) { oocPointIndex = polygonIndex = threadIndex = 0 ; polygons.resize(numMaxThreads); }
 template< class Vertex , typename Index >
 void CoredVectorMeshData< Vertex , Index >::resetIterator ( void ) { oocPointIndex = polygonIndex = threadIndex = 0; }
 template< class Vertex , typename Index >
@@ -115,13 +115,13 @@ CoredFileMeshData< Index , VertexFactory >::CoredFileMeshData( const VertexFacto
 {
 	_threadIndex = 0;
 	_oocVertexNum = 0;
-	_polygonNum.resize( std::thread::hardware_concurrency() );
+	_polygonNum.resize(numMaxThreads);
 	for( unsigned int i=0 ; i<_polygonNum.size() ; i++ ) _polygonNum[i] = 0;
 
 	char _fileHeader[1024];
 	sprintf( _fileHeader , "%s_points_" , fileHeader );
 	_oocVertexFile = new BufferedReadWriteFile( NULL , _fileHeader );
-	_polygonFiles.resize( std::thread::hardware_concurrency() );
+	_polygonFiles.resize(numMaxThreads);
 	for( unsigned int i=0 ; i<_polygonFiles.size() ; i++ )
 	{
 		sprintf( _fileHeader , "%s_polygons_t%d_" , fileHeader , i );

--- a/Src/EDTInHeat.cpp
+++ b/Src/EDTInHeat.cpp
@@ -75,7 +75,7 @@ cmdLineParameter< int >
 #endif // _OPENMP
 	ScheduleType( "schedule" , (int)ThreadPool::DefaultSchedule ) ,
 	ThreadChunkSize( "chunkSize" , (int)ThreadPool::DefaultChunkSize ) ,
-	Threads( "threads" , (int)std::thread::hardware_concurrency() );
+	Threads( "threads" , (int)numMaxThreads);
 
 cmdLineParameter< float >
 	Scale( "scale" , 2.f ) ,

--- a/Src/FEMTree.h
+++ b/Src/FEMTree.h
@@ -2106,7 +2106,7 @@ public:
 		const DenseNodeData< T , FEMSignatures >& _coefficients;
 		DenseNodeData< T , FEMSignatures > _coarseCoefficients;
 	public:
-		_MultiThreadedEvaluator( const FEMTree* tree , const DenseNodeData< T , FEMSignatures >& coefficients , int threads=std::thread::hardware_concurrency() );
+		_MultiThreadedEvaluator( const FEMTree* tree , const DenseNodeData< T , FEMSignatures >& coefficients , int threads= numMaxThreads);
 		template< unsigned int _PointD=PointD > CumulativeDerivativeValues< T , Dim , _PointD > values( Point< Real , Dim > p , int thread=0 , const FEMTreeNode* node=NULL );
 		template< unsigned int _PointD=PointD > CumulativeDerivativeValues< T , Dim , _PointD > centerValues( const FEMTreeNode* node , int thread=0 );
 		template< unsigned int _PointD=PointD > CumulativeDerivativeValues< T , Dim , _PointD > cornerValues( const FEMTreeNode* node , int corner , int thread=0 );
@@ -2120,7 +2120,7 @@ public:
 		std::vector< ConstPointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > > _neighborKeys;
 		const DensityEstimator< DensityDegree >& _density;
 	public:
-		MultiThreadedWeightEvaluator( const FEMTree* tree , const DensityEstimator< DensityDegree >& density , int threads=std::thread::hardware_concurrency() );
+		MultiThreadedWeightEvaluator( const FEMTree* tree , const DensityEstimator< DensityDegree >& density , int threads= numMaxThreads);
 		Real weight( Point< Real , Dim > p , int thread=0 );
 	};
 
@@ -2136,7 +2136,7 @@ public:
 		typename FEMIntegrator::template PointEvaluator< UIntPack< FEMSigs ... > , ZeroUIntPack< Dim > > *_pointEvaluator;
 		const SparseNodeData< T , FEMSignatures >& _coefficients;
 	public:
-		MultiThreadedSparseEvaluator( const FEMTree* tree , const SparseNodeData< T , FEMSignatures >& coefficients , int threads=std::thread::hardware_concurrency() );
+		MultiThreadedSparseEvaluator( const FEMTree* tree , const SparseNodeData< T , FEMSignatures >& coefficients , int threads= numMaxThreads);
 		~MultiThreadedSparseEvaluator( void ){ if( _pointEvaluator ) delete _pointEvaluator; }
 		void addValue( Point< Real , Dim > p , T &t , int thread=0 , const FEMTreeNode* node=NULL );
 	};

--- a/Src/FEMTree.inl
+++ b/Src/FEMTree.inl
@@ -54,7 +54,7 @@ template< unsigned int Dim , class Real > FEMTree< Dim , Real >::FEMTree( size_t
 {
 	if( blockSize )
 	{
-		nodeAllocators.resize( std::thread::hardware_concurrency() );
+		nodeAllocators.resize(numMaxThreads);
 		for( size_t i=0 ; i<nodeAllocators.size() ; i++ )
 		{
 			nodeAllocators[i] = new Allocator< FEMTreeNode >();
@@ -80,7 +80,7 @@ FEMTree< Dim , Real >::FEMTree( FILE* fp , XForm< Real , Dim+1 > &xForm , size_t
 {
 	if( blockSize )
 	{
-		nodeAllocators.resize( std::thread::hardware_concurrency() );
+		nodeAllocators.resize(numMaxThreads);
 		for( size_t i=0 ; i<nodeAllocators.size() ; i++ )
 		{
 			nodeAllocators[i] = new Allocator< FEMTreeNode >();

--- a/Src/ImageStitching.cpp
+++ b/Src/ImageStitching.cpp
@@ -64,7 +64,7 @@ cmdLineParameter< int >
 #endif // _OPENMP
 	ScheduleType( "schedule" , (int)ThreadPool::DefaultSchedule ) ,
 	ThreadChunkSize( "chunkSize" , (int)ThreadPool::DefaultChunkSize ) ,
-	Threads( "threads" , (int)std::thread::hardware_concurrency() ) ,
+	Threads( "threads" , (int)numMaxThreads) ,
 	MaxMemoryGB( "maxMemory" , 0 ) ,
 	GSIterations( "iters" , 8 ) ,
 	FullDepth( "fullDepth" , 6 ) ,

--- a/Src/MyMiscellany.h
+++ b/Src/MyMiscellany.h
@@ -466,7 +466,7 @@ struct ThreadPool
 
 	static unsigned int NumThreads( void ){ return (unsigned int)_Threads.size()+1; }
 
-	static void Init( ParallelType parallelType , unsigned int numThreads=std::thread::hardware_concurrency() )
+	static void Init( ParallelType parallelType , unsigned int numThreads= numMaxThreads)
 	{
 		_ParallelType = parallelType;
 		if( _Threads.size() && !_Close )

--- a/Src/PointInterpolant.cpp
+++ b/Src/PointInterpolant.cpp
@@ -94,7 +94,7 @@ cmdLineParameter< int >
 #endif // _OPENMP
 	ScheduleType( "schedule" , (int)ThreadPool::DefaultSchedule ) ,
 	ThreadChunkSize( "chunkSize" , (int)ThreadPool::DefaultChunkSize ) ,
-	Threads( "threads" , (int)std::thread::hardware_concurrency() );
+	Threads( "threads" , (int)numMaxThreads);
 
 cmdLineParameter< float >
 	Scale( "scale" , 1.1f ) ,

--- a/Src/PoissonRecon.cpp
+++ b/Src/PoissonRecon.cpp
@@ -113,7 +113,7 @@ cmdLineParameter< int >
 #endif // _OPENMP
 	ScheduleType( "schedule" , (int)ThreadPool::DefaultSchedule ) ,
 	ThreadChunkSize( "chunkSize" , (int)ThreadPool::DefaultChunkSize ) ,
-	Threads( "threads" , (int)std::thread::hardware_concurrency() );
+	Threads( "threads" , (int)numMaxThreads);
 
 cmdLineParameter< float >
 	DataX( "data" , 32.f ) ,

--- a/Src/PreProcessor.h
+++ b/Src/PreProcessor.h
@@ -47,4 +47,12 @@ DAMAGE.
 #define VERSION "13.72"							// The version of the code
 #define MEMORY_ALLOCATOR_BLOCK_SIZE 1<<12		// The chunk size for memory allocation
 
+
+#ifdef _OPENMP
+#include <omp.h>
+int numMaxThreads = omp_get_num_procs();
+#else // !_OPENMP
+int numMaxThreads = std::thread::hardware_concurrency();
+#endif // _OPENMP
+
 #endif // PRE_PROCESSOR_INCLUDED

--- a/Src/SSDRecon.cpp
+++ b/Src/SSDRecon.cpp
@@ -109,7 +109,7 @@ cmdLineParameter< int >
 #endif // _OPENMP
 	ScheduleType( "schedule" , (int)ThreadPool::DefaultSchedule ) ,
 	ThreadChunkSize( "chunkSize" , (int)ThreadPool::DefaultChunkSize ) ,
-	Threads( "threads" , (int)std::thread::hardware_concurrency() );
+	Threads( "threads" , (int)numMaxThreads);
 
 cmdLineParameter< float >
 	DataX( "data" , 32.f ) ,


### PR DESCRIPTION
thread::hardware_concurrency() only takes in account max threads on one CPU ( numa group 0 )
switch to: int omp_get_num_procs(void);
The omp_get_num_procs routine returns the number of processors available to the device. ( including multi CPU's )