### PR TITLE
FEMTree: throw rather than hard-exit for invalid faces

### DIFF
--- a/Src/FEMTree.IsoSurface.specialized.inl
+++ b/Src/FEMTree.IsoSurface.specialized.inl
@@ -1421,7 +1421,7 @@ protected:
 										const std::vector< _IsoEdge >& _edges = iter->second;
 										for( size_t j=0 ; j<_edges.size() ; j++ ) edges.push_back( _IsoEdge( _edges[j][flip] , _edges[j][1-flip] ) );
 									}
-									else ERROR_OUT( "Invalid faces: " , i , "  " , fDir==HyperCube::BACK ? "back" : ( fDir==HyperCube::FRONT ? "front" : ( fDir==HyperCube::CROSS ? "cross" : "unknown" ) ) );
+									else THROW( "Invalid faces: " , i , "  " , fDir==HyperCube::BACK ? "back" : ( fDir==HyperCube::FRONT ? "front" : ( fDir==HyperCube::CROSS ? "cross" : "unknown" ) ) );
 								}
 							}
 							else
@@ -1441,7 +1441,7 @@ protected:
 										const std::vector< _IsoEdge >& _edges = iter->second;
 										for( size_t j=0 ; j<_edges.size() ; j++ ) edges.push_back( _IsoEdge( _edges[j][flip] , _edges[j][1-flip] ) );
 									}
-									else ERROR_OUT( "Invalid faces: " , i , "  " ,  fDir==HyperCube::BACK ? "back" : ( fDir==HyperCube::FRONT ? "front" : ( fDir==HyperCube::CROSS ? "cross" : "unknown" ) ) );
+									else THROW( "Invalid faces: " , i , "  " ,  fDir==HyperCube::BACK ? "back" : ( fDir==HyperCube::FRONT ? "front" : ( fDir==HyperCube::CROSS ? "cross" : "unknown" ) ) );
 								}
 							}
 						}


### PR DESCRIPTION
Via [Open3D repo PR #1](https://github.com/isl-org/Open3D-PoissonRecon/pull/1)

We have some corner cases that causes Poisson surface reconstruction to fail.
However we would rather throw (and catch and handle) exceptions, rather than terminate the broader application.