### PR TITLE
add support for reading alternate ply type names

### DIFF
--- a/Src/VertexFactory.inl
+++ b/Src/VertexFactory.inl
@@ -47,11 +47,17 @@ namespace VertexFactory
 	{
 		switch( plyType )
 		{
+		    case PLY_INT_32:
 			case PLY_INT:    return TypeOnDisk::INT;
+			case PLY_UINT_32:
 			case PLY_UINT:   return TypeOnDisk::UINT;
+			case PLY_INT_8:
 			case PLY_CHAR:   return TypeOnDisk::CHAR;
+			case PLY_UINT_8:
 			case PLY_UCHAR:  return TypeOnDisk::UCHAR;
+			case PLY_FLOAT_32:
 			case PLY_FLOAT:  return TypeOnDisk::FLOAT;
+			case PLY_FLOAT_64:
 			case PLY_DOUBLE: return TypeOnDisk::DOUBLE;
 			default: ERROR_OUT( "Unrecognized type: " , plyType );
 		}

--- a/Src/VertexFactory.inl
+++ b/Src/VertexFactory.inl
@@ -47,7 +47,7 @@ namespace VertexFactory
 	{
 		switch( plyType )
 		{
-		    case PLY_INT_32:
+			case PLY_INT_32:
 			case PLY_INT:    return TypeOnDisk::INT;
 			case PLY_UINT_32:
 			case PLY_UINT:   return TypeOnDisk::UINT;


### PR DESCRIPTION
I have a ply with the following header:

```
ply
format binary_little_endian 1.0
element vertex 187408
property float32 x
property float32 y
property float32 z
property uint8 red
property uint8 green
property uint8 blue
property float32 nx
property float32 ny
property float32 nz
end_header
```

which is failing in PoissonRecon with the following error:

```
> ./PoissonRecon --in scene_dense.ply --out poisson-12.ply --depth 12 --density --verbose
[WARNING] Src/PoissonRecon.cpp (Line 1038)
          main
          Compiled for degree-1, boundary-Neumann, single-precision _only_
[ERROR] Src/VertexFactory.inl (Line 56)
        FromPlyType
        Unrecognized type: 12
```

Even though these types are known and defined in PlyFile.h, they are not supported by the `FromPlyType` function.  I searched the issues list and couldn't find anything about this issue.  I'm surprised I have not seen this issue, which makes me think I am doing something wrong.   This PR adds support for remapping the alternate type names to the internally supported types and fixes the failure I was having.

