### PR TITLE
Use ThreadPool::NumThreads over hardware_concurrency

### DIFF
--- a/Src/FEMTree.h
+++ b/Src/FEMTree.h
@@ -2525,7 +2525,7 @@ namespace PoissonRecon
 			const DenseNodeData< T , FEMSignatures >& _coefficients;
 			DenseNodeData< T , FEMSignatures > _coarseCoefficients;
 		public:
-			_MultiThreadedEvaluator( const FEMTree* tree , const DenseNodeData< T , FEMSignatures >& coefficients , int threads=std::thread::hardware_concurrency() );
+			_MultiThreadedEvaluator( const FEMTree* tree , const DenseNodeData< T , FEMSignatures >& coefficients , int threads=ThreadPool::NumThreads() );
 			template< unsigned int _PointD=PointD > CumulativeDerivativeValues< T , Dim , _PointD > values( Point< Real , Dim > p , int thread=0 , const FEMTreeNode* node=NULL );
 			template< unsigned int _PointD=PointD > CumulativeDerivativeValues< T , Dim , _PointD > centerValues( const FEMTreeNode* node , int thread=0 );
 			template< unsigned int _PointD=PointD > CumulativeDerivativeValues< T , Dim , _PointD > cornerValues( const FEMTreeNode* node , int corner , int thread=0 );
@@ -2539,7 +2539,7 @@ namespace PoissonRecon
 			std::vector< ConstPointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > > _neighborKeys;
 			const DensityEstimator< DensityDegree >& _density;
 		public:
-			MultiThreadedWeightEvaluator( const FEMTree* tree , const DensityEstimator< DensityDegree >& density , int threads=std::thread::hardware_concurrency() );
+			MultiThreadedWeightEvaluator( const FEMTree* tree , const DensityEstimator< DensityDegree >& density , int threads=ThreadPool::NumThreads() );
 			Real weight( Point< Real , Dim > p , int thread=0 );
 		};
 
@@ -2555,7 +2555,7 @@ namespace PoissonRecon
 			typename FEMIntegrator::template PointEvaluator< UIntPack< FEMSigs ... > , ZeroUIntPack< Dim > > *_pointEvaluator;
 			const SparseNodeData< T , FEMSignatures >& _coefficients;
 		public:
-			MultiThreadedSparseEvaluator( const FEMTree* tree , const SparseNodeData< T , FEMSignatures >& coefficients , int threads=std::thread::hardware_concurrency() );
+			MultiThreadedSparseEvaluator( const FEMTree* tree , const SparseNodeData< T , FEMSignatures >& coefficients , int threads=ThreadPool::NumThreads() );
 			~MultiThreadedSparseEvaluator( void ){ if( _pointEvaluator ) delete _pointEvaluator; }
 			void addValue( Point< Real , Dim > p , T &t , int thread=0 , const FEMTreeNode* node=NULL );
 			template< typename AccumulationFunctor/*=std::function< void ( const T & , Real s ) > */ >

--- a/Src/FEMTree.inl
+++ b/Src/FEMTree.inl
@@ -337,7 +337,7 @@ FEMTree< Dim , Real >::FEMTree( size_t blockSize ) : _nodeInitializer( *this ) ,
 {
 	if( blockSize )
 	{
-		nodeAllocators.resize( std::thread::hardware_concurrency() );
+		nodeAllocators.resize( ThreadPool::NumThreads() );
 		for( size_t i=0 ; i<nodeAllocators.size() ; i++ )
 		{
 			nodeAllocators[i] = new Allocator< FEMTreeNode >();

--- a/Src/Reconstructors.streams.h
+++ b/Src/Reconstructors.streams.h
@@ -240,7 +240,7 @@ namespace PoissonRecon
 
 			OutputInputFaceStream( void )
 			{
-				size_t sz = std::thread::hardware_concurrency();
+				size_t sz = ThreadPool::NumThreads();
 
 				_backingVectors.resize( sz , nullptr );
 
@@ -293,7 +293,7 @@ namespace PoissonRecon
 
 			~OutputInputFaceStream( void )
 			{
-				size_t sz = std::thread::hardware_concurrency();
+				size_t sz = ThreadPool::NumThreads();
 
 				delete _backingVector;
 				delete _backingFile;
@@ -351,7 +351,7 @@ namespace PoissonRecon
 			OutputInputFactoryTypeStream( Factory &factory , std::function< Vertex ( const Position< Real , Dim > & , const Gradient< Real , Dim > & , const Weight< Real > & , const Data & ...  ) > converter )
 				: _converter( converter )
 			{
-				size_t sz = std::thread::hardware_concurrency();
+				size_t sz = ThreadPool::NumThreads();
 
 				_backingVectors.resize( sz , nullptr );
 
@@ -399,7 +399,7 @@ namespace PoissonRecon
 
 			~OutputInputFactoryTypeStream( void )
 			{
-				size_t sz = std::thread::hardware_concurrency();
+				size_t sz = ThreadPool::NumThreads();
 
 				delete _backingVector;
 				delete _backingFile;


### PR DESCRIPTION
When replacing `ThreadPool::NumThreads()` to use `tbb::this_task_arena::max_concurrency()`, the value can end up being different from `std::thread::hardware_concurrency()`. On AMD EPYC 9454P I ended up with values of 48 for the STL concurrency and 96 for the TBB max concurrency.