### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/JPEG/jdpostct.cpp
+++ b/JPEG/jdpostct.cpp
@@ -132,6 +132,11 @@ post_process_1pass (j_decompress_ptr cinfo,
   my_post_ptr post = (my_post_ptr) cinfo->post;
   JDIMENSION num_rows, max_rows;
 
+  /* read_and_discard_scanlines may call it with rows "available", but no buffer */
+  if (output_buf == NULL) {
+    return;
+  }
+
   /* Fill the buffer, but not more than what we can dump out in one go. */
   /* Note we rely on the upsampler to detect bottom of image. */
   max_rows = out_rows_avail - *out_row_ctr;
@@ -288,3 +293,7 @@ jinit_d_post_controller (j_decompress_ptr cinfo, boolean need_full_buffer)
     }
   }
 }
+  if (output_buf == NULL && num_rows) {
+    ERREXIT(cinfo, JERR_BAD_PARAM);
+  }
+


### PR DESCRIPTION
## Summary
This PR fixes a potential security vulnerability in cloned code that appears to have missed an upstream security patch.

## Details
- **Affected file**: `JPEG/jdpostct.cpp`
- **Upstream fix commit**: https://github.com/libjpeg-turbo/libjpeg-turbo/commit/1ecd9a5729d78518397889a630e3534bd9d963a8
- **Clone similarity score**: 0.995082

## What this PR does
- Applies the upstream security fix logic to the cloned implementation in this repository.

## References
- Upstream patch commit: https://github.com/libjpeg-turbo/libjpeg-turbo/commit/1ecd9a5729d78518397889a630e3534bd9d963a8

Please review and merge this PR to ensure your repository is protected against this potential vulnerability. 
Thank you for your time !
