### PR TITLE
Chore: standardize WIN32 macro usage to _WIN32

### DIFF
--- a/Src/CmdLineParser.h
+++ b/Src/CmdLineParser.h
@@ -40,9 +40,9 @@ DAMAGE.
 
 namespace PoissonRecon
 {
-#ifdef WIN32
+#ifdef _WIN32
 	int strcasecmp( const char* c1 , const char* c2 );
-#endif // WIN32
+#endif // _WIN32
 
 	class CmdLineReadable
 	{

--- a/Src/CmdLineParser.inl
+++ b/Src/CmdLineParser.inl
@@ -26,9 +26,9 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
 DAMAGE.
 */
 
-#if defined( WIN32 ) || defined( _WIN64 )
+#if defined( _WIN32 ) || defined( _WIN64 )
 inline int strcasecmp( const char* c1 , const char* c2 ){ return _stricmp( c1 , c2 ); }
-#endif // WIN32 || _WIN64
+#endif // _WIN32 || _WIN64
 
 template< > inline void         CmdLineType< char*       >::CleanUp( char** t ){ if( *t ) free( *t ) ; *t = NULL; }
 
@@ -59,21 +59,21 @@ void CmdLineType< Point< Real , Dim > >::WriteValue( Point< Real , Dim > t , cha
 	sprintf( str+start , "}" );
 }
 
-#if defined( WIN32 ) || defined( _WIN64 )
+#if defined( _WIN32 ) || defined( _WIN64 )
 template< > inline char*  CmdLineType< char*       >::Copy( char* t ){ return _strdup( t ); }
-#else // !WIN32 && !_WIN64
+#else // !_WIN32 && !_WIN64
 template< > inline char*  CmdLineType< char*       >::Copy( char* t ){ return strdup( t ); }
-#endif // WIN32 || _WIN64
+#endif // _WIN32 || _WIN64
 
 template< > inline int          CmdLineType< int          >::StringToType( const char* str ){ return atoi( str ); }
 template< > inline unsigned int CmdLineType< unsigned int >::StringToType( const char* str ){ return (unsigned int)atoll( str ); }
 template< > inline float        CmdLineType< float        >::StringToType( const char* str ){ return float( atof( str ) ); }
 template< > inline double       CmdLineType< double       >::StringToType( const char* str ){ return double( atof( str ) ); }
-#if defined( WIN32 ) || defined( _WIN64 )
+#if defined( _WIN32 ) || defined( _WIN64 )
 template< > inline char *       CmdLineType< char*        >::StringToType( const char* str ){ return _strdup( str ); }
-#else // !WIN32 && !_WIN64
+#else // !_WIN32 && !_WIN64
 template< > inline char *       CmdLineType< char*        >::StringToType( const char* str ){ return  strdup( str ); }
-#endif // WIN32 || _WIN64
+#endif // _WIN32 || _WIN64
 template< > inline std::string  CmdLineType< std::string  >::StringToType( const char* str ){ return std::string( str ); }
 
 template< typename Real , unsigned int Dim >
@@ -113,11 +113,11 @@ Point< Real , Dim > CmdLineType< Point< Real , Dim > >::StringToType( const char
 /////////////////////
 // CmdLineReadable //
 /////////////////////
-#if defined( WIN32 ) || defined( _WIN64 )
+#if defined( _WIN32 ) || defined( _WIN64 )
 inline CmdLineReadable::CmdLineReadable( const char *name ) : set(false) { this->name = _strdup( name ); }
-#else // !WIN32 && !_WIN64
+#else // !_WIN32 && !_WIN64
 inline CmdLineReadable::CmdLineReadable( const char *name ) : set(false) { this->name =  strdup( name ); }
-#endif // WIN32 || _WIN64
+#endif // _WIN32 || _WIN64
 
 inline CmdLineReadable::~CmdLineReadable( void ){ if( name ) free( name ) ; name = NULL; }
 inline int CmdLineReadable::read( char** , int ){ set = true ; return 0; }

--- a/Src/Image.h
+++ b/Src/Image.h
@@ -199,15 +199,15 @@ namespace PoissonRecon
 
 	inline bool ImageReader::ValidExtension( const char *ext )
 	{
-#ifdef WIN32
+#ifdef _WIN32
 		if     ( !_stricmp( ext , "jpeg" ) || !_stricmp( ext , "jpg" ) ) return true;
 		else if( !_stricmp( ext , "png" )                              ) return true;
 		else if( !_stricmp( ext , "iGrid" )                            ) return true;
-#else // !WIN32
+#else // !_WIN32
 		if( !strcasecmp( ext , "jpeg" ) || !strcasecmp( ext , "jpg" ) ) return true;
 		else if( !strcasecmp( ext , "png" )                           ) return true;
 		else if( !strcasecmp( ext , "iGrid" )                         ) return true;
-#endif // WIN32
+#endif // _WIN32
 		return false;
 	}
 
@@ -216,15 +216,15 @@ namespace PoissonRecon
 		unsigned int width , height , channels;
 		ImageReader* reader = NULL;
 		char* ext = FileNameParser::Extension( fileName );
-#ifdef WIN32
+#ifdef _WIN32
 		if     ( !_stricmp( ext , "jpeg" ) || !_stricmp( ext , "jpg" ) ) reader = new       JPEGReader( fileName , width , height , channels );
 		else if( !_stricmp( ext , "png" )                              ) reader = new        PNGReader( fileName , width , height , channels );
 		else if( !_stricmp( ext , "iGrid" )                            ) reader = new TiledImageReader( fileName , width , height , channels );
-#else // !WIN32
+#else // !_WIN32
 		if( !strcasecmp( ext , "jpeg" ) || !strcasecmp( ext , "jpg" ) ) reader = new       JPEGReader( fileName , width , height , channels );
 		else if( !strcasecmp( ext , "png" )                           ) reader = new        PNGReader( fileName , width , height , channels );
 		else if( !strcasecmp( ext , "iGrid" )                         ) reader = new TiledImageReader( fileName , width , height , channels );
-#endif // WIN32
+#endif // _WIN32
 		else
 		{
 			delete[] ext;
@@ -240,33 +240,33 @@ namespace PoissonRecon
 	inline void ImageReader::GetInfo( const char* fileName , unsigned int& width , unsigned int& height , unsigned int& channels )
 	{
 		char* ext = FileNameParser::Extension( fileName );
-#ifdef WIN32
+#ifdef _WIN32
 		if( !_stricmp( ext , "jpeg" ) || !_stricmp( ext , "jpg" ) ) JPEGReader::GetInfo( fileName , width , height , channels );
 		else if( !_stricmp( ext , "png" ) )                          PNGReader::GetInfo( fileName , width , height , channels );
 		else if( !_stricmp( ext , "iGrid" ) )                 TiledImageReader::GetInfo( fileName , width , height , channels );
-#else // !WIN32
+#else // !_WIN32
 		if( !strcasecmp( ext , "jpeg" ) || !strcasecmp( ext , "jpg" ) ) JPEGReader::GetInfo( fileName , width , height , channels );
 		else if( !strcasecmp( ext , "png" ) )                            PNGReader::GetInfo( fileName , width , height , channels );
 		else if( !strcasecmp( ext , "iGrid" ) )                   TiledImageReader::GetInfo( fileName , width , height , channels );
-#endif // WIN32
+#endif // _WIN32
 		delete[] ext;
 	}
 
 	inline bool ImageWriter::ValidExtension( const char *ext )
 	{
-#ifdef WIN32
+#ifdef _WIN32
 		if( !_stricmp( ext , "jpeg" ) || !_stricmp( ext , "jpg" ) ) return true;
 		else if( !_stricmp( ext , "png" ) )                         return true;
 #ifdef SUPPORT_TILES
 		else if( !_stricmp( ext , "iGrid" ) )                       return true;
 #endif // SUPPORT_TILES
-#else // !WIN32
+#else // !_WIN32
 		if( !strcasecmp( ext , "jpeg" ) || !strcasecmp( ext , "jpg" ) ) return true;
 		else if( !strcasecmp( ext , "png" ) )                           return true;
 #ifdef SUPPORT_TILES
 		else if( !strcasecmp( ext , "iGrid" ) )                         return true;
 #endif // SUPPORT_TILES
-#endif // WIN32
+#endif // _WIN32
 		return false;
 	}
 
@@ -274,19 +274,19 @@ namespace PoissonRecon
 	{
 		ImageWriter* writer = NULL;
 		char* ext = FileNameParser::Extension( fileName );
-#ifdef WIN32
+#ifdef _WIN32
 		if( !_stricmp( ext , "jpeg" ) || !_stricmp( ext , "jpg" ) ) writer = new JPEGWriter( fileName , width , height , channels , params.quality );
 		else if( !_stricmp( ext , "png" ) ) writer = new PNGWriter( fileName , width , height , channels , params.quality );
 #ifdef SUPPORT_TILES
 		else if( !_stricmp( ext , "iGrid" ) ) writer = new TiledImageWriter( fileName , width , height , channels , params );
 #endif // SUPPORT_TILES
-#else // !WIN32
+#else // !_WIN32
 		if( !strcasecmp( ext , "jpeg" ) || !strcasecmp( ext , "jpg" ) ) writer = new JPEGWriter( fileName , width , height , channels , params.quality );
 		else if( !strcasecmp( ext , "png" ) ) writer = new PNGWriter( fileName , width , height , channels , params.quality );
 #ifdef SUPPORT_TILES
 		else if( !strcasecmp( ext , "iGrid" ) ) writer = new TiledImageWriter( fileName , width , height , channels , params );
 #endif // SUPPORT_TILES
-#endif // WIN32
+#endif // _WIN32
 		else
 		{
 			delete[] ext;

--- a/Src/LinearSolvers.h
+++ b/Src/LinearSolvers.h
@@ -3,10 +3,10 @@
 
 #ifdef USE_CHOLMOD
 #include <Cholmod/cholmod.h>
-#if defined( WIN32 ) || defined( _WIN64 )
+#if defined( _WIN32 ) || defined( _WIN64 )
 #pragma message( "[WARNING] Need to explicitly exclude VCOMP.lib" )
 #pragma comment( lib , "CHOLMOD_FULL.lib" )
-#endif // WIN32 || _WIN64
+#endif // _WIN32 || _WIN64
 #ifdef DLONG
 typedef long long SOLVER_LONG;
 #define CHOLMOD( name ) cholmod_l_ ## name

--- a/Src/MyMiscellany.h
+++ b/Src/MyMiscellany.h
@@ -93,15 +93,15 @@ namespace PoissonRecon
 	////////////////
 	inline double Time( void )
 	{
-#ifdef WIN32
+#ifdef _WIN32
 		struct _timeb t;
 		_ftime( &t );
 		return double( t.time ) + double( t.millitm ) / 1000.0;
-#else // WIN32
+#else // !_WIN32
 		struct timeval t;
 		gettimeofday( &t , NULL );
 		return t.tv_sec + double( t.tv_usec ) / 1000000;
-#endif // WIN32
+#endif // _WIN32
 	}
 
 	struct Timer


### PR DESCRIPTION
This PR updates macro usage in multiple files:

- Rename all instances of WIN32 to _WIN32
- No functional changes, only standardization

This change ensures consistency with the common convention for platform macros.